### PR TITLE
bug fix for sketchesDir

### DIFF
--- a/wizards/arduino/wizard.script
+++ b/wizards/arduino/wizard.script
@@ -60,7 +60,7 @@ Libs <- _T("");
 
 // directories
 ArduinoDir <- _T("$(HOME)/.codeblocks/arduino");
-SketchDir <- _T("$(HOME)/.codeblocks/sketches");
+SketchesDir <- _T("$(HOME)/.codeblocks/sketches");
 HelpersDir <- _T("$(HOME)/.codeblocks/helpers");
 ArdusimDir <- _T("$(HOME)/.codeblocks/ardusim");
 
@@ -321,7 +321,7 @@ function CreateTarget(project, targetName, processor, variant, protocol, baudrat
 						target.SetVar(_T("UPLOAD_BAUDRATE"), baudrate, false);
 						target.SetVar(_T("UPLOAD_PORT"), AvrPort, false);
 						target.SetVar(_T("ARDUINO_DIR"), ArduinoDir, false);
-						target.SetVar(_T("SKETCH_DIR"), SketchDir, false);
+						target.SetVar(_T("SKETCH_DIR"), SketchesDir, false);
             target.SetVar(_T("CPU_FREQ"), cpu_freq, false);
             target.SetVar(_T("MAX_SIZE"), max_size, false);
             target.SetVar(_T("MAX_SRAM"), max_sram, false);


### PR DESCRIPTION
SketchDir should be SketchesDir.  
This caused the program to crash after starting.  I had this error on Ubuntu 12.04
